### PR TITLE
Recruitment 2018

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
       to the wider UBC tech community through Launch Pad events.
     </p>
     <p class="large">
-      If you would like further information or are interested in becoming a sponsor, please <a href="mailto:president@ubclaunchpad.com">contact us</a>!
+      If you would like further information or are interested in becoming a sponsor, please <a href="mailto:presidents@ubclaunchpad.com">contact us</a>!
     </p>
     <a href="https://github.com">
       <div class="sponsor" id="github"></div>
@@ -617,7 +617,7 @@
         </a>
       </div>
       <div class="icon">
-        <a href="mailto:president@ubclaunchpad.com">
+        <a href="mailto:presidents@ubclaunchpad.com">
           <i class="fa fa-lg fa-envelope"></i>
         </a>
       </div>

--- a/index.html
+++ b/index.html
@@ -416,12 +416,12 @@
   <!-- JOIN -->
   <div id="join">
     <h1>Join Us</h1>
-    <!-- <p class="large">
+    <p class="large">
       If you are a programmer or designer at UBC and are looking for the opportunity to work on interesting projects with fun people
       please don't hesitate to get in contact with us by emailing
-      <a href="mailto:team@ubclaunchpad.com">team@ubclaunchpad.com</a>.
+      <a href="mailto:presidents@ubclaunchpad.com">presidents@ubclaunchpad.com</a>.
     </p>
-    <br /> -->
+    <!-- <br />
     <p class="large">
       Applications are currently open! Apply by 12AM on Saturday, September 8th.
     </p>
@@ -460,7 +460,7 @@
         </div>
         <a class="button" href="https://goo.gl/forms/BxXNoLg0pVJf5KlD3">APPLY</a>
       </div>
-    </div>
+    </div> -->
   </div>
 
   <!-- FAQ -->
@@ -543,10 +543,10 @@
       </a>
       <div class="panel">
         <p class="small">
-          Teams are formed at the start of every term, usually consisting of a tech lead, 3-6 developers, and a designer. 
-          Each team works on a project from inception to deployment. Teams can build anything they're excited about, 
-          as long as they can commit to finishing and releasing it within one or two terms. 
-          We generally don't monetize our projects or build software for external organizations. 
+          Teams are formed at the start of every term, usually consisting of a tech lead, 3-6 developers, and a designer.
+          Each team works on a project from inception to deployment. Teams can build anything they're excited about,
+          as long as they can commit to finishing and releasing it within one or two terms.
+          We generally don't monetize our projects or build software for external organizations.
           But ultimately, each team decides what they want to build;
           for example, the Machine Learning team once chose to enter a Kaggle competition for their term project.
         </p>


### PR DESCRIPTION
Commented out the application part of the `Join us` section and replaced the old, incorrect email address references with new ones.